### PR TITLE
Building out a test suite with mock API functionality

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -17,7 +17,14 @@ package targetprocess
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Example of client.Get() for godoc
@@ -33,4 +40,253 @@ func ExampleClient_Get() {
 	}
 	jsonBytes, _ := json.Marshal(response)
 	fmt.Print(string(jsonBytes))
+}
+
+// Helpers for fake client
+type roundTripFunc func(req *http.Request) *http.Response
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+var mockEmptyResponse = `
+{
+	"Items": []
+}
+`
+var stringBreaksURL = string(byte(0x7f))
+
+// NewFakeClient returns a client that will respond to very specific requests in order to build out unit tests
+// Responses are based on a set of basic JSON objects built from actual TargetProcess queries
+func NewFakeClient() *Client {
+	c := NewClient("testing", "abc123")
+	c.Client = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) *http.Response {
+			resp := &http.Response{
+				StatusCode: 200,
+			}
+			path := r.URL.Path
+			if r.Method == http.MethodGet {
+				switch path {
+				case "/api/v1/UserStory/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockUserStoryResponse))
+				case "/api/v1/UserStories/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockUserStoriesResponse))
+				case "/api/v1/Project/":
+					if query, ok := r.URL.Query()["where"]; ok {
+						if query[0] == "(Name eq 'MockProject2')" {
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockProjectResponseSingle))
+							return resp
+						}
+						resp.Body = ioutil.NopCloser(strings.NewReader(mockEmptyResponse))
+						return resp
+					}
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockProjectResponse))
+				case "/api/v1/Projects/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockProjectResponseSingle))
+				case "/api/v1/Process/":
+					if query, ok := r.URL.Query()["where"]; ok {
+						switch query[0] {
+						case "(Id eq 1)":
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockProcessResponse1))
+							return resp
+						case "(Id eq 2)":
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockProcessResponse2))
+							return resp
+						default:
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockEmptyResponse))
+							return resp
+						}
+					}
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockProcessResponse))
+				case "/api/v1/Processes/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockProcessResponse2))
+				case "/api/v1/Team/":
+					if query, ok := r.URL.Query()["where"]; ok {
+						switch query[0] {
+						case "(Name eq 'MockTeam1')":
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockTeamResponse1))
+							return resp
+						default:
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockEmptyResponse))
+							return resp
+						}
+					}
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockTeamResponse))
+				case "/api/v1/Teams/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockTeamResponse2))
+				case "/api/v1/Feature/":
+					if query, ok := r.URL.Query()["where"]; ok {
+						switch query[0] {
+						case "(Name eq 'MockFeature1')":
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockFeatureResponse1))
+							return resp
+						case "(Name eq 'MockFeature2')":
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockFeatureResponse2))
+							return resp
+						default:
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockEmptyResponse))
+							return resp
+						}
+					}
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockFeatureResponse))
+				case "/api/v1/Features/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockFeatureResponse2))
+				case "/api/v1/User/":
+					if query, ok := r.URL.Query()["where"]; ok {
+						switch query[0] {
+						case "(Id eq 1)":
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockUserResponse1))
+							return resp
+						case "(Id eq 2)":
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockUserResponse2))
+							return resp
+						default:
+							resp.Body = ioutil.NopCloser(strings.NewReader(mockEmptyResponse))
+							return resp
+						}
+					}
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockUserResponse))
+				case "/api/v1/Users/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockUserResponse2))
+				case "/api/v1/BasicJSON/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(`{"one":"two"}`))
+				case "/api/v1/BadJSON/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(``))
+				default:
+					resp.Body = ioutil.NopCloser(strings.NewReader(`One or more errors occurred.`))
+					resp.StatusCode = 404
+				}
+			}
+
+			if r.Method == http.MethodPost {
+				switch path {
+				case "/api/v1/UserStory/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(mockUserStoryResponse))
+				case "/api/v1/BasicJSON/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(`{"one":"two"}`))
+				case "/api/v1/BadJSON/":
+					resp.Body = ioutil.NopCloser(strings.NewReader(``))
+				default:
+					resp.Body = ioutil.NopCloser(strings.NewReader(`One or more errors occurred.`))
+				}
+			}
+
+			return resp
+		}),
+	}
+	return c
+}
+
+// Client Unit Tests
+func TestGetWithBadUrl(t *testing.T) {
+	c := NewClient("", "")
+	target := map[string]interface{}{}
+
+	err := c.Get(target, "project", nil)
+	assert.EqualError(t, err, "HTTP request failure on https://.tpondemand.com/api/v1//project: Get \"https://.tpondemand.com/api/v1/project/?format=json&resultFormat=json\": dial tcp: lookup .tpondemand.com: no such host")
+}
+
+func TestClient_Get(t *testing.T) {
+	tests := []struct {
+		name       string
+		want       interface{}
+		entityType string
+		values     []string
+
+		// Error handling
+		wantErr    bool
+		errMessage string
+	}{
+		{
+			name:       "basic json test",
+			want:       map[string]string{"one": "two"},
+			wantErr:    false,
+			entityType: "BasicJSON",
+		},
+		{
+			name:       "JSON decode failure error",
+			wantErr:    true,
+			errMessage: "JSON decode failed on BadJSON:\n: unexpected end of JSON input",
+			entityType: "BadJSON",
+		},
+		{
+			name:       "bad url format in entity type",
+			wantErr:    true,
+			entityType: stringBreaksURL,
+			errMessage: "Error parsing entity type: \u007f: parse \"\\u007f/\": net/url: invalid control character in URL",
+		},
+		{
+			name:       "return 400",
+			wantErr:    true,
+			errMessage: "HTTP request failure on :\n404: One or more errors occurred.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewFakeClient()
+			out := make(map[string]string)
+			values := url.Values{
+				"test": tt.values,
+			}
+			err := c.Get(&out, tt.entityType, values)
+			if tt.wantErr {
+				assert.EqualErrorf(t, err, tt.errMessage, "expected an error")
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, out)
+			}
+		})
+	}
+}
+
+func TestClient_Post(t *testing.T) {
+	tests := []struct {
+		name       string
+		want       interface{}
+		entityType string
+		body       []byte
+
+		// Error handling
+		wantErr    bool
+		errMessage string
+	}{
+		{
+			name:       "basic json test",
+			want:       map[string]string{"one": "two"},
+			wantErr:    false,
+			entityType: "BasicJSON",
+		},
+		{
+			name:       "JSON decode failure error",
+			wantErr:    true,
+			errMessage: "JSON decode failed on BadJSON:\n: unexpected end of JSON input",
+			entityType: "BadJSON",
+		},
+		{
+			name:       "bad url format in entity type",
+			wantErr:    true,
+			entityType: stringBreaksURL,
+			errMessage: "Error parsing entity type: \u007f: parse \"\\u007f/\": net/url: invalid control character in URL",
+		},
+		{
+			name:       "return 404",
+			wantErr:    true,
+			errMessage: "JSON decode failed on :\nOne or more errors occurred.: invalid character 'O' looking for beginning of value",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewFakeClient()
+			out := make(map[string]string)
+
+			err := c.Post(&out, tt.entityType, nil, tt.body)
+			if tt.wantErr {
+				assert.EqualErrorf(t, err, tt.errMessage, "expected an error")
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, out)
+			}
+		})
+	}
 }

--- a/entity.go
+++ b/entity.go
@@ -22,7 +22,7 @@ type EntityState struct {
 	NumericPriority   float64      `json:",omitempty"`
 	ParentEntityState *EntityState `json:",omitempty"`
 	Process           *Process     `json:",omitempty"`
-	IsInital          bool         `json:",omitempty"`
+	IsInitial         bool         `json:",omitempty"`
 	IsFinal           bool         `json:",omitempty"`
 	IsPlanned         bool         `json:",omitempty"`
 	IsCommentRequired bool         `json:",omitempty"`

--- a/feature.go
+++ b/feature.go
@@ -77,7 +77,7 @@ func (c *Client) GetFeature(name string) (Feature, error) {
 		return Feature{}, errors.Wrap(err, fmt.Sprintf("error getting feature with name '%s'", name))
 	}
 	if len(out.Items) < 1 {
-		return ret, fmt.Errorf("no items found")
+		return ret, fmt.Errorf("no features found")
 	}
 	ret = out.Items[0]
 	ret.client = c

--- a/feature_test.go
+++ b/feature_test.go
@@ -1,0 +1,206 @@
+// Copyright 2020 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package targetprocess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var mockFeature1 = Feature{
+	ID:   1,
+	Name: "Feature1",
+	Project: &Project{
+		ID:   2,
+		Name: "MockProject2",
+	},
+	NumericPriority: float32(13375),
+}
+
+var mockFeature2 = Feature{
+	ID:   2,
+	Name: "Feature2",
+	Project: &Project{
+		ID:   2,
+		Name: "MockProject2",
+	},
+	NumericPriority: float32(13375),
+}
+
+var mockFeatureResponse = `
+{
+	"Next": "https://testing.tpondemand.com/api/v1/Features/?format=json&take=25&skip=25",
+	"Items": [
+	  {
+		"ResourceType": "Feature",
+		"Id": 1,
+		"Name": "Feature1",
+		"Description": null,
+		"StartDate": null,
+		"EndDate": null,
+		"LastCommentDate": null,
+		"Tags": "",
+		"NumericPriority": 13375,
+		"Effort": 0,
+		"EffortCompleted": 0,
+		"EffortToDo": 0,
+		"Progress": 0,
+		"TimeSpent": 0,
+		"TimeRemain": 0,
+		"PlannedStartDate": null,
+		"PlannedEndDate": null,
+		"InitialEstimate": 0,
+		"Project": {
+		  "ResourceType": "Project",
+		  "Id": 2,
+		  "Name": "MockProject2"
+		}
+	  }
+	]
+  }
+`
+var mockFeatureResponse1 = `
+{
+	"Items": [
+	  {
+		"ResourceType": "Feature",
+		"Id": 1,
+		"Name": "Feature1",
+		"Description": null,
+		"StartDate": null,
+		"EndDate": null,
+		"LastCommentDate": null,
+		"Tags": "",
+		"NumericPriority": 13375,
+		"Effort": 0,
+		"EffortCompleted": 0,
+		"EffortToDo": 0,
+		"Progress": 0,
+		"TimeSpent": 0,
+		"TimeRemain": 0,
+		"PlannedStartDate": null,
+		"PlannedEndDate": null,
+		"InitialEstimate": 0,
+		"Project": {
+		  "ResourceType": "Project",
+		  "Id": 2,
+		  "Name": "MockProject2"
+		}
+	  }
+	]
+  }
+`
+
+var mockFeatureResponse2 = `
+{
+	"Items": [
+	  {
+		"ResourceType": "Feature",
+		"Id": 2,
+		"Name": "Feature2",
+		"Description": null,
+		"StartDate": null,
+		"EndDate": null,
+		"LastCommentDate": null,
+		"Tags": "",
+		"NumericPriority": 13375,
+		"Effort": 0,
+		"EffortCompleted": 0,
+		"EffortToDo": 0,
+		"Progress": 0,
+		"TimeSpent": 0,
+		"TimeRemain": 0,
+		"PlannedStartDate": null,
+		"PlannedEndDate": null,
+		"InitialEstimate": 0,
+		"Project": {
+		  "ResourceType": "Project",
+		  "Id": 2,
+		  "Name": "MockProject2"
+		}
+	  }
+	]
+  }  
+`
+
+func TestClient_GetFeatures(t *testing.T) {
+	client := NewFakeClient()
+
+	tests := []struct {
+		name    string
+		filters []QueryFilter
+		want    []Feature
+		wantErr bool
+	}{
+		{
+			name:    "no filter",
+			filters: nil,
+			want: []Feature{
+				mockFeature1,
+				mockFeature2,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetFeatures(tt.filters...)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestClient_GetFeature(t *testing.T) {
+	client := NewFakeClient()
+
+	tests := []struct {
+		name    string
+		feature string
+		want    Feature
+		wantErr bool
+	}{
+		{
+			name:    "no error",
+			feature: "MockFeature1",
+			want:    mockFeature1,
+			wantErr: false,
+		},
+		{
+			name:    "not fou nd",
+			feature: "dne",
+			want:    Feature{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetFeature(tt.feature)
+			// Patch client
+			tt.want.client = client
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/fairwindsops/go-targetprocess
 
 go 1.14
 
-require github.com/pkg/errors v0.9.1
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/process_test.go
+++ b/process_test.go
@@ -1,0 +1,123 @@
+// Copyright 2020 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package targetprocess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var mockProcess1 = Process{
+	ID:   1,
+	Name: "Onboarding",
+}
+
+var mockProcess2 = Process{
+	ID:          2,
+	Name:        "Kanban",
+	Description: "Kanban Board",
+}
+
+var mockProcessResponse = `
+{
+	"Next": "https://testing.tpondemand.com/api/v1/Processes/?take=25&skip=25",
+	"Items": [
+	  {
+		"ResourceType": "Process",
+		"Id": 1,
+		"Name": "Onboarding",
+		"IsDefault": false,
+		"Description": null
+	  }
+	]
+  }
+  `
+
+var mockProcessResponse2 = `
+{
+	"Items": [
+	  {
+		"ResourceType": "Process",
+		"Id": 2,
+		"Name": "Kanban",
+		"IsDefault": false,
+		"Description": "Kanban Board"
+	  }
+	]
+  }
+  `
+var mockProcessResponse1 = `
+  {
+	  "Items": [
+		{
+		  "ResourceType": "Process",
+		  "Id": 1,
+		  "Name": "Onboarding",
+		  "IsDefault": false,
+		  "Description": null
+		}
+	  ]
+	}
+	`
+
+func TestClient_GetProcesses(t *testing.T) {
+	client := NewFakeClient()
+	tests := []struct {
+		name    string
+		filters []QueryFilter
+		want    []Process
+		wantErr bool
+	}{
+		{
+			name:    "simple",
+			filters: nil,
+			want: []Process{
+				mockProcess1,
+				mockProcess2,
+			},
+			wantErr: false,
+		},
+		{
+			name: "filter",
+			filters: []QueryFilter{
+				Where("Id eq 2"),
+			},
+			want: []Process{
+				mockProcess2,
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty",
+			filters: []QueryFilter{
+				Where("Id eq 4"),
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetProcesses(tt.filters...)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/project.go
+++ b/project.go
@@ -84,7 +84,7 @@ func (c *Client) GetProject(name string) (Project, error) {
 		return Project{}, errors.Wrap(err, fmt.Sprintf("error getting project with name '%s'", name))
 	}
 	if len(out.Items) < 1 {
-		return ret, fmt.Errorf("no items found")
+		return ret, fmt.Errorf("no projects found")
 	}
 	ret = out.Items[0]
 	ret.client = c

--- a/project_test.go
+++ b/project_test.go
@@ -1,0 +1,237 @@
+// Copyright 2020 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package targetprocess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var mockProject1 = Project{
+	ID:              1,
+	Name:            "MockProject1",
+	Description:     "Project 1 Description",
+	Abbreviation:    "P1",
+	NumericPriority: float64(1116),
+	CreateDate:      "/Date(1553311554000-0500)/",
+	ModifyDate:      "/Date(1563297019000-0500)/",
+	Effort:          float32(58),
+	EffortCompleted: float32(58),
+}
+
+var mockProject2 = Project{
+	ID:              2,
+	Name:            "MockProject2",
+	Abbreviation:    "P2",
+	NumericPriority: float64(1116),
+	Description:     "Project 2 Description",
+	CreateDate:      "/Date(1553311554000-0500)/",
+	ModifyDate:      "/Date(1563297019000-0500)/",
+	Effort:          float32(58),
+	EffortCompleted: float32(58),
+	// This is not a mistake. It would seem that the API only returns a stub of the process here, missing the description.
+	Process: &Process{
+		ID:   2,
+		Name: "Kanban",
+	},
+}
+
+var mockProjectResponse = `
+{
+	"Next": "https://testing.tpondemand.com/api/v1/Projects/?format=json&take=25&skip=25",
+	"Items": [
+	  {
+		"ResourceType": "Project",
+		"Id": 1,
+		"Name": "MockProject1",
+		"Description": "Project 1 Description",
+		"StartDate": null,
+		"EndDate": null,
+		"CreateDate": "/Date(1553311554000-0500)/",
+		"ModifyDate": "/Date(1563297019000-0500)/",
+		"LastCommentDate": null,
+		"Tags": "",
+		"NumericPriority": 1116,
+		"Effort": 58,
+		"EffortCompleted": 58,
+		"EffortToDo": 0,
+		"IsActive": false,
+		"IsProduct": false,
+		"Abbreviation": "P1",
+		"MailReplyAddress": null,
+		"Color": null,
+		"Progress": 1,
+		"PlannedStartDate": null,
+		"PlannedEndDate": null,
+		"IsPrivate": null
+	  }
+	]
+}`
+
+var mockProjectResponseSingle = `
+{
+	"Items": [
+	  {
+		"ResourceType": "Project",
+		"Id": 2,
+		"Name": "MockProject2",
+		"Description": "Project 2 Description",
+		"StartDate": null,
+		"EndDate": null,
+		"CreateDate": "/Date(1553311554000-0500)/",
+		"ModifyDate": "/Date(1563297019000-0500)/",
+		"LastCommentDate": null,
+		"Tags": "",
+		"NumericPriority": 1116,
+		"Effort": 58,
+		"EffortCompleted": 58,
+		"EffortToDo": 0,
+		"IsActive": false,
+		"IsProduct": false,
+		"Abbreviation": "P2",
+		"MailReplyAddress": null,
+		"Color": null,
+		"Progress": 1,
+		"PlannedStartDate": null,
+		"PlannedEndDate": null,
+		"IsPrivate": null,
+		"Process": {
+		  "ResourceType": "Process",
+		  "Id": 2,
+		  "Name": "Kanban"
+		}
+	  }
+	]
+  }  
+`
+
+func TestClient_GetProjects(t *testing.T) {
+	client := NewFakeClient()
+
+	tests := []struct {
+		name    string
+		filters []QueryFilter
+		want    []Project
+		wantErr bool
+	}{
+		{
+			name:    "simple",
+			filters: nil,
+			want: []Project{
+				mockProject1,
+				mockProject2,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetProjects(tt.filters...)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestProject_GetProcess(t *testing.T) {
+	tests := []struct {
+		name    string
+		project Project
+		want    *Process
+		wantErr bool
+	}{
+		{
+			name:    "simple",
+			project: mockProject2,
+			want:    &mockProcess2,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.project.client = NewFakeClient()
+			got, err := tt.project.GetProcess()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestProject_NewUserStory(t *testing.T) {
+	client := NewFakeClient()
+	tests := []struct {
+		name        string
+		project     Project
+		description string
+		team        string
+
+		want    UserStory
+		wantErr bool
+	}{
+		{
+			name:        "simple",
+			project:     mockProject2,
+			description: "description",
+			want: UserStory{
+				client:      client,
+				Team:        &mockTeam1,
+				Project:     &mockProject2,
+				Name:        "simple",
+				Description: "description",
+			},
+			team:    "MockTeam1",
+			wantErr: false,
+		},
+		{
+			name:        "team dne",
+			project:     mockProject2,
+			description: "failure",
+			team:        "dne",
+			want: UserStory{
+				client:      client,
+				Team:        &mockTeam1,
+				Project:     &mockProject2,
+				Name:        "simple",
+				Description: "description",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Patch the clients
+			tt.project.client = client
+			tt.want.Team.client = client
+			tt.want.Project.client = client
+
+			got, err := tt.project.NewUserStory(tt.name, tt.description, tt.team)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/team.go
+++ b/team.go
@@ -56,10 +56,33 @@ func (c *Client) GetTeam(name string) (Team, error) {
 		return ret, errors.Wrap(err, fmt.Sprintf("error getting team with name '%s'", name))
 	}
 	if len(out.Items) < 1 {
-		return ret, fmt.Errorf("no items found")
+		return ret, fmt.Errorf("no teams found")
 	}
 	ret = out.Items[0]
 	ret.client = c
+	return ret, nil
+}
+
+// GetTeams will return a list of teams
+func (c *Client) GetTeams(filters ...QueryFilter) ([]Team, error) {
+	var ret []Team
+	out := TeamResponse{}
+
+	err := c.Get(&out, "Team", nil, filters...)
+	if err != nil {
+		return nil, err
+	}
+	ret = append(ret, out.Items...)
+	for out.Next != "" {
+		innerOut := TeamResponse{}
+		err := c.GetNext(&innerOut, out.Next)
+		if err != nil {
+			return ret, err
+		}
+		ret = append(ret, innerOut.Items...)
+		out = innerOut
+	}
+
 	return ret, nil
 }
 

--- a/team_test.go
+++ b/team_test.go
@@ -1,0 +1,200 @@
+// Copyright 2020 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package targetprocess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var mockTeam1 = Team{
+	ID:              1,
+	Name:            "MockTeam1",
+	Abbreviation:    "T1",
+	CreateDate:      "/Date(1536962113000-0500)/",
+	ModifyDate:      "/Date(1593723490000-0500)/",
+	NumericPriority: 12,
+}
+
+var mockTeam2 = Team{
+	ID:              2,
+	Name:            "MockTeam2",
+	Abbreviation:    "T2",
+	CreateDate:      "/Date(1536962113000-0500)/",
+	ModifyDate:      "/Date(1593723490000-0500)/",
+	NumericPriority: 12,
+}
+
+var mockTeamResponse = `
+{
+	"Next": "https://testing.tpondemand.com/api/v1/Teams/?take=25&skip=25",
+	"Items": [
+	  {
+		"ResourceType": "Team",
+		"Id": 1,
+		"Name": "MockTeam1",
+		"Description": null,
+		"StartDate": null,
+		"EndDate": null,
+		"CreateDate": "/Date(1536962113000-0500)/",
+		"ModifyDate": "/Date(1593723490000-0500)/",
+		"LastCommentDate": null,
+		"Tags": "",
+		"NumericPriority": 12,
+		"Icon": null,
+		"EmojiIcon": null,
+		"IsActive": true,
+		"Abbreviation": "T1"
+	  }
+	]
+  }  
+`
+var mockTeamResponse1 = `
+{
+	"Items": [
+	  {
+		"ResourceType": "Team",
+		"Id": 1,
+		"Name": "MockTeam1",
+		"Description": null,
+		"StartDate": null,
+		"EndDate": null,
+		"CreateDate": "/Date(1536962113000-0500)/",
+		"ModifyDate": "/Date(1593723490000-0500)/",
+		"LastCommentDate": null,
+		"Tags": "",
+		"NumericPriority": 12,
+		"Icon": null,
+		"EmojiIcon": null,
+		"IsActive": true,
+		"Abbreviation": "T1"
+	  }
+	]
+  }  
+`
+
+var mockTeamResponse2 = `
+{
+	"Items": [
+	  {
+		"ResourceType": "Team",
+		"Id": 2,
+		"Name": "MockTeam2",
+		"Description": null,
+		"StartDate": null,
+		"EndDate": null,
+		"CreateDate": "/Date(1536962113000-0500)/",
+		"ModifyDate": "/Date(1593723490000-0500)/",
+		"LastCommentDate": null,
+		"Tags": "",
+		"NumericPriority": 12,
+		"Icon": null,
+		"EmojiIcon": null,
+		"IsActive": true,
+		"Abbreviation": "T2"
+	  }
+	]
+  }  
+`
+
+func TestClient_GetTeam(t *testing.T) {
+	client := NewFakeClient()
+
+	tests := []struct {
+		name    string
+		team    string
+		want    Team
+		wantErr bool
+	}{
+		{
+			name:    "team 1",
+			team:    "MockTeam1",
+			want:    mockTeam1,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetTeam(tt.team)
+			// Patch the client
+			tt.want.client = client
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestClient_GetTeams(t *testing.T) {
+	client := NewFakeClient()
+	tests := []struct {
+		name    string
+		filters []QueryFilter
+		want    []Team
+		wantErr bool
+	}{
+		{
+			name:    "no filter",
+			filters: nil,
+			want: []Team{
+				mockTeam1,
+				mockTeam2,
+			},
+			wantErr: false,
+		},
+		{
+			name: "filter",
+			filters: []QueryFilter{
+				Where("Name eq 'MockTeam1'"),
+			},
+			want: []Team{
+				mockTeam1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "no results",
+			filters: []QueryFilter{
+				Where("Name eq 'dne'"),
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetTeams(tt.filters...)
+
+			// Patch clients
+			for i := range got {
+				got[i].client = client
+			}
+			for i := range tt.want {
+				tt.want[i].client = client
+			}
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/user.go
+++ b/user.go
@@ -43,7 +43,7 @@ func (c *Client) GetUsers(filters ...QueryFilter) ([]User, error) {
 	var ret []User
 	out := UserResponse{}
 
-	err := c.Get(&out, "Users", nil, filters...)
+	err := c.Get(&out, "User", nil, filters...)
 	if err != nil {
 		return nil, err
 	}

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,172 @@
+// Copyright 2020 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package targetprocess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var mockUser1 = User{
+	ID:        1,
+	FirstName: "Mock",
+	LastName:  "User",
+	Email:     "mockuser@example.com",
+	Login:     "mockuser",
+	IsActive:  true,
+}
+
+var mockUser2 = User{
+	ID:        2,
+	FirstName: "Mock",
+	LastName:  "User",
+	Email:     "mockuser2@example.com",
+	Login:     "mockuser2",
+	IsActive:  true,
+}
+
+var mockUserResponse = `
+{
+	"Next": "https://testing.tpondemand.com/api/v1/Users/?format=json&take=25&skip=25",
+	"Items": [
+	  {
+		"ResourceType": "User",
+		"Kind": "User",
+		"Id": 1,
+		"FirstName": "Mock",
+		"LastName": "User",
+		"Email": "mockuser@example.com",
+		"Login": "mockuser",
+		"DeleteDate": null,
+		"IsActive": true,
+		"IsAdministrator": false,
+		"Locale": null,
+		"WeeklyAvailableHours": 40,
+		"CurrentAllocation": 100,
+		"CurrentAvailableHours": 0,
+		"AvailableFutureAllocation": 100,
+		"AvailableFutureHours": 40,
+		"IsObserver": false,
+		"IsContributor": false,
+		"Skills": null,
+		"ActiveDirectoryName": null,
+		"RichEditor": "Markdown"
+	  }
+	]
+}
+`
+
+var mockUserResponse1 = `
+{
+	"Items": [
+	  {
+		"ResourceType": "User",
+		"Kind": "User",
+		"Id": 1,
+		"FirstName": "Mock",
+		"LastName": "User",
+		"Email": "mockuser@example.com",
+		"Login": "mockuser",
+		"DeleteDate": null,
+		"IsActive": true,
+		"IsAdministrator": false,
+		"Locale": null,
+		"WeeklyAvailableHours": 40,
+		"CurrentAllocation": 100,
+		"CurrentAvailableHours": 0,
+		"AvailableFutureAllocation": 100,
+		"AvailableFutureHours": 40,
+		"IsObserver": false,
+		"IsContributor": false,
+		"Skills": null,
+		"ActiveDirectoryName": null,
+		"RichEditor": "Markdown"
+	  }
+	]
+}
+`
+
+var mockUserResponse2 = `
+{
+	"Items": [
+	  {
+		"ResourceType": "User",
+		"Kind": "User",
+		"Id": 2,
+		"FirstName": "Mock",
+		"LastName": "User",
+		"Email": "mockuser2@example.com",
+		"Login": "mockuser2",
+		"DeleteDate": null,
+		"IsActive": true,
+		"IsAdministrator": false,
+		"Locale": null,
+		"WeeklyAvailableHours": 40,
+		"CurrentAllocation": 100,
+		"CurrentAvailableHours": 0,
+		"AvailableFutureAllocation": 100,
+		"AvailableFutureHours": 40,
+		"IsObserver": false,
+		"IsContributor": false,
+		"Skills": null,
+		"ActiveDirectoryName": null,
+		"RichEditor": "Markdown"
+	  }
+	]
+}
+`
+
+func TestClient_GetUsers(t *testing.T) {
+	client := NewFakeClient()
+
+	tests := []struct {
+		name    string
+		filters []QueryFilter
+		want    []User
+		wantErr bool
+	}{
+		{
+			name:    "no filter",
+			filters: nil,
+			want: []User{
+				mockUser1,
+				mockUser2,
+			},
+			wantErr: false,
+		},
+		{
+			name: "filter 1",
+			filters: []QueryFilter{
+				Where("Id eq 1"),
+			},
+			want: []User{
+				mockUser1,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetUsers(tt.filters...)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/userstory_test.go
+++ b/userstory_test.go
@@ -1,0 +1,301 @@
+// Copyright 2020 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package targetprocess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var mockUserStory1 = UserStory{
+	ID:              12345,
+	Name:            "Some user story name",
+	Description:     "<!--markdown-->Some user story description",
+	StartDate:       "/Date(1599065504000-0500)/",
+	EndDate:         "",
+	CreateDate:      "/Date(1599065469000-0500)/",
+	ModifyDate:      "/Date(1599065505000-0500)/",
+	NumericPriority: 13340.313369934804,
+	CustomFields: []CustomField{
+		{
+			Name:  "Estimated Effort",
+			Type:  "Number",
+			Value: float64(0),
+		},
+	},
+	Project: &Project{
+		ID:   1,
+		Name: "MockProject1",
+	},
+	LastStateChangeDate: "/Date(1599065504000-0500)/",
+	Team: &Team{
+		ID:   1,
+		Name: "MockTeam1",
+	},
+}
+
+var mockUserStory2 = UserStory{
+	ID:              12346,
+	Name:            "Some user story name",
+	Description:     "<!--markdown-->Some user story description",
+	StartDate:       "/Date(1599065504000-0500)/",
+	EndDate:         "",
+	CreateDate:      "/Date(1599065469000-0500)/",
+	ModifyDate:      "/Date(1599065505000-0500)/",
+	NumericPriority: 13340.313369934804,
+	CustomFields: []CustomField{
+		{
+			Name: "Work Category",
+			Type: "DropDown",
+		},
+	},
+	Project: &Project{
+		ID:   2,
+		Name: "MockProject2",
+		Process: &Process{
+			ID: 2,
+		},
+	},
+	LastStateChangeDate: "/Date(1599065504000-0500)/",
+	Team: &Team{
+		ID:   1,
+		Name: "MockTeam1",
+	},
+}
+
+var mockUserStoryResponse = `
+{
+	"Next": "https://testing.tpondemand.com/api/v1/UserStories/?take=25&skip=25",
+	"Items": [
+	  {
+		"ResourceType": "UserStory",
+		"Id": 12345,
+		"Name": "Some user story name",
+		"Description": "<!--markdown-->Some user story description",
+		"StartDate": "/Date(1599065504000-0500)/",
+		"EndDate": null,
+		"CreateDate": "/Date(1599065469000-0500)/",
+		"ModifyDate": "/Date(1599065505000-0500)/",
+		"LastCommentDate": null,
+		"Tags": "",
+		"NumericPriority": 13340.313369934804,
+		"Effort": 0,
+		"EffortCompleted": 0,
+		"EffortToDo": 0,
+		"Progress": 0,
+		"TimeSpent": 0,
+		"TimeRemain": 0,
+		"LastStateChangeDate": "/Date(1599065504000-0500)/",
+		"PlannedStartDate": null,
+		"PlannedEndDate": null,
+		"InitialEstimate": 0,
+		"Units": "pt",
+		"EntityType": {
+		  "ResourceType": "EntityType",
+		  "Id": 4,
+		  "Name": "UserStory"
+		},
+		"Project": {
+		  "ResourceType": "Project",
+		  "Id": 1,
+		  "Name": "MockProject1"
+		},
+		"LastCommentedUser": null,
+		"LinkedTestPlan": null,
+		"Milestone": null,
+		"Release": null,
+		"Iteration": null,
+		"TeamIteration": null,
+		"Team": {
+		  "ResourceType": "Team",
+		  "Id": 1,
+		  "Name": "MockTeam1"
+		},
+		"Priority": {
+		  "ResourceType": "Priority",
+		  "Id": 5,
+		  "Name": "Nice To Have",
+		  "Importance": 5
+		},
+		"Feature": null,
+		"Build": null,
+		"CustomFields": [
+		  {
+			"Name": "Estimated Effort",
+			"Type": "Number",
+			"Value": 0
+		  }
+		]
+	  }
+	]
+  }  
+`
+var mockUserStoriesResponse = `
+{
+	"Items": [
+	  {
+		"ResourceType": "UserStory",
+		"Id": 12346,
+		"Name": "Some user story name",
+		"Description": "<!--markdown-->Some user story description",
+		"StartDate": "/Date(1599065504000-0500)/",
+		"EndDate": null,
+		"CreateDate": "/Date(1599065469000-0500)/",
+		"ModifyDate": "/Date(1599065505000-0500)/",
+		"LastCommentDate": null,
+		"Tags": "",
+		"NumericPriority": 13340.313369934804,
+		"Effort": 0,
+		"EffortCompleted": 0,
+		"EffortToDo": 0,
+		"Progress": 0,
+		"TimeSpent": 0,
+		"TimeRemain": 0,
+		"LastStateChangeDate": "/Date(1599065504000-0500)/",
+		"PlannedStartDate": null,
+		"PlannedEndDate": null,
+		"InitialEstimate": 0,
+		"Units": "pt",
+		"EntityType": {
+		  "ResourceType": "EntityType",
+		  "Id": 4,
+		  "Name": "UserStory"
+		},
+		"Project": {
+		  "ResourceType": "Project",
+		  "Id": 2,
+		  "Name": "MockProject2",
+		  "Process": {
+			"ResourceType": "Process",
+			"Id": 2
+		  }
+		},
+		"LastCommentedUser": null,
+		"LinkedTestPlan": null,
+		"Milestone": null,
+		"Release": null,
+		"Iteration": null,
+		"TeamIteration": null,
+		"Team": {
+		  "ResourceType": "Team",
+		  "Id": 1,
+		  "Name": "MockTeam1"
+		},
+		"CustomFields": [
+		  {
+			"Name": "Work Category",
+			"Type": "DropDown",
+			"Value": null
+		  }
+		]
+	  }
+	]
+  }  
+`
+
+func TestClient_GetUserStories(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		filters []QueryFilter
+		want    []UserStory
+		wantErr bool
+	}{
+		{
+			name:    "simple",
+			filters: nil,
+			want: []UserStory{
+				mockUserStory1,
+				mockUserStory2,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewFakeClient()
+			got, err := c.GetUserStories(tt.filters...)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestNewUserStory(t *testing.T) {
+	client := NewFakeClient()
+	type args struct {
+		c           *Client
+		name        string
+		description string
+		project     string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    UserStory
+		wantErr bool
+	}{
+		{
+			name: "simple",
+			args: args{
+				c:           client,
+				name:        "test story",
+				description: "test description",
+				project:     "MockProject2",
+			},
+			want: UserStory{
+				client:      client,
+				Name:        "test story",
+				Description: "test description",
+				Project:     &mockProject2,
+			},
+			wantErr: false,
+		},
+		{
+			name: "error",
+			args: args{
+				c:           client,
+				name:        "test story",
+				description: "test description",
+				project:     "none",
+			},
+			want: UserStory{
+				client:      client,
+				Name:        "test story",
+				Description: "test description",
+				Project:     &mockProject1,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewUserStory(tt.args.c, tt.args.name, tt.args.description, tt.args.project)
+			// We have to patch the mockProject with our client to get this to work.
+			tt.want.Project.client = client
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes  #18

Due to how inter-related all the TP objects are, I elected to put the entire "Mock API" into a single big round trip function. Each entity has its own json strings and response objects to work with that are returned by that "API".