### PR TITLE
Utilize v2 targetprocess API for GETs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: lint test
 lint:
 	golangci-lint run
 test:
-	printf "\n\nTests:\n\n"
+	@printf "\nTests:\n"
 	$(GOCMD) test -v --bench --benchmem -coverprofile coverage.txt -covermode=atomic ./...
 	GO111MODULE=on $(GOCMD) vet ./... 2> govet-report.out
 	GO111MODULE=on $(GOCMD) tool cover -html=coverage.txt -o cover-report.html

--- a/client.go
+++ b/client.go
@@ -106,10 +106,8 @@ func NewClient(account, token string) (*Client, error) {
 
 // WithContext takes a context.Context, sets it as context on the client and returns
 // a Client pointer.
-func (c *Client) WithContext(ctx context.Context) *Client {
-	newC := *c
-	newC.ctx = ctx
-	return &newC
+func (c *Client) WithContext(ctx context.Context) {
+	c.ctx = ctx
 }
 
 // Get is a generic HTTP GET call to the targetprocess api passing in the type of entity and any query filters

--- a/client.go
+++ b/client.go
@@ -33,6 +33,14 @@ const (
 	userAgent = "go-targetprocess"
 )
 
+var (
+	defaultClient *http.Client
+)
+
+func init() {
+	defaultClient = http.DefaultClient
+}
+
 // Client is the API client for Targetprocess. Create this using NewClient.
 // This can also be constructed manually but it isn't recommended.
 type Client struct {
@@ -74,7 +82,7 @@ type logger interface {
 // token is your user access token taken from your account settings
 // see here: https://dev.targetprocess.com/docs/authentication#token-authentication
 func NewClient(account, token string) (*Client, error) {
-	c := http.DefaultClient
+	c := defaultClient
 	c.Timeout = 15 * time.Second
 	baseURLString := fmt.Sprintf("https://%s.tpondemand.com/api/v1/", account)
 	baseURLReadOnlyString := fmt.Sprintf("https://%s.tpondemand.com/api/v2/", account)
@@ -216,7 +224,7 @@ func (c *Client) do(out interface{}, req *http.Request, urlPath string) error {
 
 func (c *Client) defaultParams(v url.Values) url.Values {
 	if c.Token != "" {
-		v.Add("access_token", c.Token)
+		v.Add("accessToken", c.Token)
 	}
 	v.Set("format", "json")
 	v.Set("resultFormat", "json")

--- a/client.go
+++ b/client.go
@@ -73,18 +73,18 @@ type logger interface {
 //
 // token is your user access token taken from your account settings
 // see here: https://dev.targetprocess.com/docs/authentication#token-authentication
-func NewClient(account, token string) *Client {
+func NewClient(account, token string) (*Client, error) {
 	c := http.DefaultClient
 	c.Timeout = 15 * time.Second
 	baseURLString := fmt.Sprintf("https://%s.tpondemand.com/api/v1/", account)
 	baseURLReadOnlyString := fmt.Sprintf("https://%s.tpondemand.com/api/v2/", account)
 	baseURL, err := url.Parse(baseURLString)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	baseURLReadOnly, err := url.Parse(baseURLReadOnlyString)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	return &Client{
 		baseURL:         baseURL,
@@ -93,7 +93,7 @@ func NewClient(account, token string) *Client {
 		Token:           token,
 		UserAgent:       userAgent,
 		ctx:             context.Background(),
-	}
+	}, nil
 }
 
 // WithContext takes a context.Context, sets it as context on the client and returns
@@ -194,7 +194,7 @@ func (c *Client) do(out interface{}, req *http.Request, urlPath string) error {
 
 	// Empty the body and close it to reuse the Transport
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, resp.Body) // nolint:golint,errcheck
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
 

--- a/client_test.go
+++ b/client_test.go
@@ -22,9 +22,13 @@ import (
 
 // Example of client.Get() for godoc
 func ExampleClient_Get() {
-	tpClient := NewClient("exampleaccount", "superSecretToken")
+	tpClient, err := NewClient("exampleaccount", "superSecretToken")
+	if err != nil {
+		fmt.Println("Failed to create tp client:", err)
+		os.Exit(1)
+	}
 	var response = UserResponse{}
-	err := tpClient.Get(response,
+	err = tpClient.Get(response,
 		"User",
 		nil)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -15,10 +15,51 @@
 package targetprocess
 
 import (
+	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+const (
+	okResponse = `{
+		"items": [],
+        "next": "",
+        "prev": ""
+	}`
+)
+
+type genericResponse struct {
+	Items []string `json:"items"`
+	Next  string   `json:"next"`
+	Prev  string   `json:"prev"`
+}
+
+func newMockClient(handler http.Handler, account, token string) (*Client, func()) {
+	s := httptest.NewTLSServer(handler)
+
+	defaultClient = &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, network, _ string) (net.Conn, error) {
+				return net.Dial(network, s.Listener.Addr().String())
+			},
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+
+	client, _ := NewClient(account, token)
+
+	return client, s.Close
+}
 
 // Example of client.Get() for godoc
 func ExampleClient_Get() {
@@ -37,4 +78,88 @@ func ExampleClient_Get() {
 	}
 	jsonBytes, _ := json.Marshal(response)
 	fmt.Print(string(jsonBytes))
+}
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name        string
+		account     string
+		accessToken string
+		entity      string
+		path        string
+	}{
+		{
+			name:        "Users GET",
+			account:     "example",
+			accessToken: "1234abcd",
+			entity:      "Users",
+		},
+	}
+
+	for _, tt := range tests {
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			queryParams := r.URL.Query()
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, fmt.Sprintf("%s.tpondemand.com", tt.account), r.Host)
+			assert.Equal(t, fmt.Sprintf("/api/v2/%s/", tt.entity), r.URL.Path)
+			assert.Equal(t, tt.accessToken, queryParams.Get("accessToken"))
+			assert.Equal(t, "json", queryParams.Get("format"))
+			assert.Equal(t, "json", queryParams.Get("resultFormat"))
+			assert.Equal(t, "go-targetprocess", r.Header.Get("User-Agent"))
+			assert.Equal(t, "application/json", r.Header.Get("Accept"))
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			_, _ = w.Write([]byte(okResponse))
+		})
+		mockClient, teardown := newMockClient(h, tt.account, tt.accessToken)
+
+		resp := new(genericResponse)
+		err := mockClient.Get(resp, tt.entity, nil)
+		teardown()
+		if err != nil {
+			t.Logf("error sending get: %s", err)
+			t.Fail()
+		}
+	}
+}
+
+func TestPost(t *testing.T) {
+	tests := []struct {
+		name        string
+		account     string
+		accessToken string
+		entity      string
+		path        string
+	}{
+		{
+			name:        "Users POST",
+			account:     "example",
+			accessToken: "1234abcd",
+			entity:      "UserStory",
+		},
+	}
+
+	for _, tt := range tests {
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			queryParams := r.URL.Query()
+			assert.Equal(t, "POST", r.Method)
+			assert.Equal(t, fmt.Sprintf("%s.tpondemand.com", tt.account), r.Host)
+			assert.Equal(t, fmt.Sprintf("/api/v1/%s/", tt.entity), r.URL.Path)
+			assert.Equal(t, tt.accessToken, queryParams.Get("accessToken"))
+			assert.Equal(t, "json", queryParams.Get("format"))
+			assert.Equal(t, "json", queryParams.Get("resultFormat"))
+			assert.Equal(t, "go-targetprocess", r.Header.Get("User-Agent"))
+			assert.Equal(t, "application/json", r.Header.Get("Accept"))
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			_, _ = w.Write([]byte(okResponse))
+		})
+		mockClient, teardown := newMockClient(h, tt.account, tt.accessToken)
+
+		resp := new(genericResponse)
+		err := mockClient.Post(resp, tt.entity, nil, nil)
+		teardown()
+		if err != nil {
+			t.Logf("error sending get: %s", err)
+			t.Fail()
+		}
+	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -83,7 +83,6 @@ func ExampleClient_Get() {
 func TestWithContext(t *testing.T) {
 
 	type contextKey string
-
 	var testContextKey contextKey = "test"
 
 	tests := []struct {

--- a/filters.go
+++ b/filters.go
@@ -54,7 +54,7 @@ func MaxPerPage(count int) QueryFilter {
 // entire result set, such as getting the average Effort value
 // across multiple items.
 //
-// It is important to not that this changes the output json and
+// It is important to note that this changes the output json and
 // therefore you will need to adjust your receiving struct
 func Result(query string) QueryFilter {
 	return func(values url.Values) (url.Values, error) {

--- a/filters.go
+++ b/filters.go
@@ -38,7 +38,7 @@ func First() QueryFilter {
 
 // MaxPerPage is how many results we will allow to return per page. Default enforced by the API is 25.
 // If a negative number is passed in it will be converted to a positive number. In the TP API, a negative
-// number has the same return as a positive, so we'll
+// number has the same return as a positive, but we convert any negative to positive anyway.
 func MaxPerPage(count int) QueryFilter {
 	return func(values url.Values) (url.Values, error) {
 		if count < 0 {

--- a/filters.go
+++ b/filters.go
@@ -18,12 +18,61 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-	"strings"
 )
 
 // QueryFilter accepts a query and returns a query, modifying
 // it in some way before sending
 type QueryFilter func(r url.Values) (url.Values, error)
+
+// First is a QueryFilter that will only return a single
+// Entity. It returns the first one encountered.
+//
+// **WARNING** if using this with a helper function that supports
+// automatic paging, ensure to set page to false (e.g. client.GetUserStories())
+func First() QueryFilter {
+	return func(values url.Values) (url.Values, error) {
+		values.Set("take", "1")
+		return values, nil
+	}
+}
+
+// MaxPerPage is how many results we will allow to return per page. Default enforced by the API is 25.
+// If a negative number is passed in it will be converted to a positive number. In the TP API, a negative
+// number has the same return as a positive, so we'll
+func MaxPerPage(count int) QueryFilter {
+	return func(values url.Values) (url.Values, error) {
+		if count < 0 {
+			count = count * -1
+		}
+		values.Set("take", strconv.Itoa(count))
+		return values, nil
+	}
+}
+
+// Result is a QueryFilter that represents the `result` parameter
+// in a url query. It is used to do custom calculations over the
+// entire result set, such as getting the average Effort value
+// across multiple items.
+//
+// It is important to not that this changes the output json and
+// therefore you will need to adjust your receiving struct
+func Result(query string) QueryFilter {
+	return func(values url.Values) (url.Values, error) {
+		values.Set("result", fmt.Sprintf("{%s}", query))
+		return values, nil
+	}
+}
+
+// Select is a QueryFilter that represents the `select` parameter
+// in a url query. It is used to determine what fields are returned.
+// It is important that the struct you are casting your results into
+// accept the fields you specify.
+func Select(query string) QueryFilter {
+	return func(values url.Values) (url.Values, error) {
+		values.Set("select", fmt.Sprintf("{%s}", query))
+		return values, nil
+	}
+}
 
 // Where is a QueryFilter that represents the `where` parameter
 // in a url query.
@@ -33,39 +82,14 @@ func Where(queries ...string) QueryFilter {
 			if _, exists := values["where"]; exists {
 				currentWhere := values.Get("where")
 				if currentWhere == "" {
-					values.Set("where", fmt.Sprintf("(%s)", query))
+					values.Set("where", query)
 					continue
 				}
-				values.Set("where", currentWhere+" and "+fmt.Sprintf("(%s)", query))
+				values.Set("where", currentWhere+" and "+query)
 			} else {
-				values.Set("where", fmt.Sprintf("(%s)", query))
+				values.Set("where", query)
 			}
 		}
-		return values, nil
-	}
-}
-
-// First is a QueryFilter that will only return a single
-// Entity. It returns the first one encountered.
-func First() QueryFilter {
-	return func(values url.Values) (url.Values, error) {
-		values.Set("take", "1")
-		return values, nil
-	}
-}
-
-// Include is used to filter what fields are returned by a given Query
-func Include(includes ...string) QueryFilter {
-	return func(values url.Values) (url.Values, error) {
-		values.Set("include", fmt.Sprintf("[%s]", strings.Join(includes, ",")))
-		return values, nil
-	}
-}
-
-// MaxPerPage is how many results we will allow to return per page. Default enforced by the API is 25.
-func MaxPerPage(count int) QueryFilter {
-	return func(values url.Values) (url.Values, error) {
-		values.Set("take", strconv.Itoa(count))
 		return values, nil
 	}
 }

--- a/filters_test.go
+++ b/filters_test.go
@@ -28,10 +28,13 @@ func matchedURLValues(expected, got url.Values, key string) (bool, string, strin
 }
 
 func ExampleFirst() {
-	tpClient := NewClient("accountName", "superSecretToken")
+	tpClient, err := NewClient("accountName", "superSecretToken")
+	if err != nil {
+		fmt.Println("Error creating tp client:", err)
+		os.Exit(1)
+	}
 	userStories, err := tpClient.GetUserStories(
 		false,
-		Where("EntityState.Name == 'Done'"),
 		First(),
 	)
 	if err != nil {
@@ -71,7 +74,11 @@ func TestFirst(t *testing.T) {
 }
 
 func ExampleMaxPerPage() {
-	tpClient := NewClient("accountName", "superSecretToken")
+	tpClient, err := NewClient("accountName", "superSecretToken")
+	if err != nil {
+		fmt.Println("Error creating tp client:", err)
+		os.Exit(1)
+	}
 	userStories, err := tpClient.GetUserStories(
 		false,
 		MaxPerPage(200),
@@ -121,11 +128,15 @@ func TestMaxPerPage(t *testing.T) {
 }
 
 func ExampleResult() {
-	tpClient := NewClient("accountName", "superSecretToken")
+	tpClient, err := NewClient("accountName", "superSecretToken")
+	if err != nil {
+		fmt.Println("Error creating tp client:", err)
+		os.Exit(1)
+	}
 	response := struct {
 		EffortSum float64 `json:",omitempty"`
 	}{}
-	err := tpClient.Get(&response,
+	err = tpClient.Get(&response,
 		"UserStories",
 		nil,
 		Result("effortSum:sum(effort)"),
@@ -175,7 +186,11 @@ func TestResult(t *testing.T) {
 }
 
 func ExampleSelect() {
-	tpClient := NewClient("accountName", "superSecretToken")
+	tpClient, err := NewClient("accountName", "superSecretToken")
+	if err != nil {
+		fmt.Println("Error creating tp client:", err)
+		os.Exit(1)
+	}
 	userStories, err := tpClient.GetUserStories(
 		false,
 		Select("name,id"),
@@ -225,7 +240,11 @@ func TestSelect(t *testing.T) {
 }
 
 func ExampleWhere() {
-	tpClient := NewClient("accountName", "superSecretToken")
+	tpClient, err := NewClient("accountName", "superSecretToken")
+	if err != nil {
+		fmt.Println("Error creating tp client:", err)
+		os.Exit(1)
+	}
 	userStories, err := tpClient.GetUserStories(
 		false,
 		Where("EntityState.Name == 'Done'"),

--- a/filters_test.go
+++ b/filters_test.go
@@ -16,14 +16,23 @@ package targetprocess
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func ExampleWhere() {
+func matchedURLValues(expected, got url.Values, key string) (bool, string, string) {
+	return expected.Get(key) == got.Get(key), expected.Get(key), got.Get(key)
+}
+
+func ExampleFirst() {
 	tpClient := NewClient("accountName", "superSecretToken")
 	userStories, err := tpClient.GetUserStories(
-		Where("EntityState.Name eq 'Done'"),
-		Where("Team.Name eq 'Team-1'"),
+		false,
+		Where("EntityState.Name == 'Done'"),
+		First(),
 	)
 	if err != nil {
 		fmt.Println("Error getting UserStories:", err)
@@ -32,21 +41,39 @@ func ExampleWhere() {
 	fmt.Printf("%+v\n", userStories)
 }
 
-func ExampleInclude() {
-	tpClient := NewClient("accountName", "superSecretToken")
-	userStories, err := tpClient.GetUserStories(
-		Include("Name", "Description"),
-	)
-	if err != nil {
-		fmt.Println("Error getting UserStories:", err)
-		os.Exit(1)
+func TestFirst(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+		want    url.Values
+	}{
+		{
+			name:    "valid",
+			wantErr: false,
+			want:    url.Values{"take": []string{"1"}},
+		},
 	}
-	fmt.Printf("%+v\n", userStories)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vals := url.Values{}
+			first := First()
+			got, err := first(vals)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				match, w, g := matchedURLValues(tt.want, got, "take")
+				assert.True(t, match)
+				assert.EqualValues(t, w, g)
+			}
+		})
+	}
 }
 
 func ExampleMaxPerPage() {
 	tpClient := NewClient("accountName", "superSecretToken")
 	userStories, err := tpClient.GetUserStories(
+		false,
 		MaxPerPage(200),
 	)
 	if err != nil {
@@ -56,15 +83,200 @@ func ExampleMaxPerPage() {
 	fmt.Printf("%+v\n", userStories)
 }
 
-func ExampleFirst() {
+func TestMaxPerPage(t *testing.T) {
+	tests := []struct {
+		name    string
+		count   int
+		wantErr bool
+		want    url.Values
+	}{
+		{
+			name:    "valid",
+			count:   100,
+			wantErr: false,
+			want:    url.Values{"take": []string{"100"}},
+		},
+		{
+			name:    "negative conversion",
+			count:   -100,
+			wantErr: false,
+			want:    url.Values{"take": []string{"100"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vals := url.Values{}
+			mpp := MaxPerPage(tt.count)
+			got, err := mpp(vals)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				match, w, g := matchedURLValues(tt.want, got, "take")
+				assert.True(t, match)
+				assert.EqualValues(t, w, g)
+			}
+		})
+	}
+}
+
+func ExampleResult() {
+	tpClient := NewClient("accountName", "superSecretToken")
+	response := struct {
+		EffortSum float64 `json:",omitempty"`
+	}{}
+	err := tpClient.Get(&response,
+		"UserStories",
+		nil,
+		Result("effortSum:sum(effort)"),
+	)
+	if err != nil {
+		fmt.Println("Error getting UserStories:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("%+v\n", response)
+}
+
+func TestResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		wantErr bool
+		want    url.Values
+	}{
+		{
+			name:    "valid",
+			query:   "effortSum:sum(effort)",
+			wantErr: false,
+			want:    url.Values{"result": []string{"{effortSum:sum(effort)}"}},
+		},
+		{
+			name:    "empty",
+			query:   "",
+			wantErr: false,
+			want:    url.Values{"result": []string{"{}"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vals := url.Values{}
+			result := Result(tt.query)
+			got, err := result(vals)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				match, w, g := matchedURLValues(tt.want, got, "result")
+				assert.True(t, match)
+				assert.EqualValues(t, w, g)
+			}
+		})
+	}
+}
+
+func ExampleSelect() {
 	tpClient := NewClient("accountName", "superSecretToken")
 	userStories, err := tpClient.GetUserStories(
-		Where("EntityState.Name eq 'Done'"),
-		First(),
+		false,
+		Select("name,id"),
 	)
 	if err != nil {
 		fmt.Println("Error getting UserStories:", err)
 		os.Exit(1)
 	}
 	fmt.Printf("%+v\n", userStories)
+}
+
+func TestSelect(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		wantErr bool
+		want    url.Values
+	}{
+		{
+			name:    "valid",
+			query:   "id,name,assignedUser.Where(login=='jane@example.com'),responsibleTeam:{responsibleTeam.id,responsibleTeam.team},entityState",
+			wantErr: false,
+			want:    url.Values{"select": []string{"{id,name,assignedUser.Where(login=='jane@example.com'),responsibleTeam:{responsibleTeam.id,responsibleTeam.team},entityState}"}},
+		},
+		{
+			name:    "empty",
+			query:   "",
+			wantErr: false,
+			want:    url.Values{"select": []string{"{}"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vals := url.Values{}
+			sel := Select(tt.query)
+			got, err := sel(vals)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				match, w, g := matchedURLValues(tt.want, got, "select")
+				assert.True(t, match)
+				assert.EqualValues(t, w, g)
+			}
+		})
+	}
+}
+
+func ExampleWhere() {
+	tpClient := NewClient("accountName", "superSecretToken")
+	userStories, err := tpClient.GetUserStories(
+		false,
+		Where("EntityState.Name == 'Done'"),
+		Where("Team.Name == 'Team-1'"),
+	)
+	if err != nil {
+		fmt.Println("Error getting UserStories:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("%+v\n", userStories)
+}
+
+func TestWhere(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   []string
+		wantErr bool
+		want    url.Values
+	}{
+		{
+			name:    "valid",
+			query:   []string{"EntityState.Name == 'Done'"},
+			wantErr: false,
+			want:    url.Values{"where": []string{"EntityState.Name == 'Done'"}},
+		},
+		{
+			name:    "multiple",
+			query:   []string{"EntityState.Name == 'Done'", "Team.Name == 'Administrators'"},
+			wantErr: false,
+			want:    url.Values{"where": []string{"EntityState.Name == 'Done' and Team.Name == 'Administrators'"}},
+		},
+		{
+			name:    "empty",
+			query:   []string{""},
+			wantErr: false,
+			want:    url.Values{"where": []string{""}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vals := url.Values{}
+			where := Where(tt.query...)
+			got, err := where(vals)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				match, w, g := matchedURLValues(tt.want, got, "where")
+				assert.True(t, match)
+				assert.EqualValues(t, w, g)
+			}
+		})
+	}
 }

--- a/general.go
+++ b/general.go
@@ -30,7 +30,7 @@ type TeamAssignment struct {
 	Team      *Team    `json:",omitempty"`
 }
 
-// UserAssignment has it's own unique Id and also includes a reference to a user, which also has an Id
+// UserAssignment has its own unique Id and also includes a reference to a user, which also has an Id
 type UserAssignment struct {
 	User
 }

--- a/general.go
+++ b/general.go
@@ -17,10 +17,9 @@ package targetprocess
 // DateTime currently does nothing special but will represent the TP DateTime objects
 type DateTime string
 
-// AssignedTeams is used in UserStories and potentially other places.
-// The AssignedTeams section of a UserStory response replaces the deprecated usage of the Team field
-type AssignedTeams struct {
-	Items []TeamAssignment
+// AssignedUser is used in UserStories and potentially other places. Returns a list of user assignments.
+type AssignedUser struct {
+	Items []UserAssignment
 }
 
 // TeamAssignment has it's own unique Id and also includes a reference to the team, which also has an Id
@@ -29,4 +28,9 @@ type TeamAssignment struct {
 	StartDate DateTime `json:",omitempty"`
 	EndDate   DateTime `json:",omitempty"`
 	Team      *Team    `json:",omitempty"`
+}
+
+// UserAssignment has it's own unique Id and also includes a reference to a user, which also has an Id
+type UserAssignment struct {
+	User
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/fairwindsops/go-targetprocess
 
 go 1.14
 
-require github.com/pkg/errors v0.9.1
+require (
+	github.com/davecgh/go-spew v1.1.0
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/userstory.go
+++ b/userstory.go
@@ -25,28 +25,29 @@ import (
 type UserStory struct {
 	client *Client
 
-	ID                  int32          `json:"Id,omitempty"`
-	Name                string         `json:",omitempty"`
-	Description         string         `json:",omitempty"`
-	StartDate           DateTime       `json:",omitempty"`
-	EndDate             DateTime       `json:",omitempty"`
-	CreateDate          DateTime       `json:",omitempty"`
-	ModifyDate          DateTime       `json:",omitempty"`
-	NumericPriority     float64        `json:",omitempty"`
-	CustomFields        []CustomField  `json:",omitempty"`
-	Effort              float32        `json:",omitempty"`
-	EffortCompleted     float32        `json:",omitempty"`
-	EffortToDo          float32        `json:",omitempty"`
-	Project             *Project       `json:",omitempty"`
-	Progress            float32        `json:",omitempty"`
-	TimeSpent           float32        `json:",omitempty"`
-	TimeRemain          float32        `json:",omitempty"`
-	LastStateChangeDate DateTime       `json:",omitempty"`
-	InitialEstimate     float32        `json:",omitempty"`
-	Team                *Team          `json:",omitempty"`
-	EntityState         *EntityState   `json:",omitempty"`
-	AssignedTeams       *AssignedTeams `json:",omitempty"`
-	Feature             *Feature       `json:",omitempty"`
+	ID                  int32           `json:"Id,omitempty"`
+	Name                string          `json:",omitempty"`
+	Description         string          `json:",omitempty"`
+	StartDate           DateTime        `json:",omitempty"`
+	EndDate             DateTime        `json:",omitempty"`
+	CreateDate          DateTime        `json:",omitempty"`
+	ModifyDate          DateTime        `json:",omitempty"`
+	NumericPriority     float64         `json:",omitempty"`
+	CustomFields        []CustomField   `json:",omitempty"`
+	Effort              float32         `json:",omitempty"`
+	EffortCompleted     float32         `json:",omitempty"`
+	EffortToDo          float32         `json:",omitempty"`
+	Project             *Project        `json:",omitempty"`
+	Progress            float32         `json:",omitempty"`
+	TimeSpent           float32         `json:",omitempty"`
+	TimeRemain          float32         `json:",omitempty"`
+	LastStateChangeDate DateTime        `json:",omitempty"`
+	InitialEstimate     float32         `json:",omitempty"`
+	ResponsibleTeam     *TeamAssignment `json:",omitempty"`
+	Team                *Team           `json:",omitempty"`
+	EntityState         *EntityState    `json:",omitempty"`
+	AssignedUser        *AssignedUser   `json:",omitempty"`
+	Feature             *Feature        `json:",omitempty"`
 }
 
 // UserStoryList is a list of user stories. Can be used to create multiple stories at once
@@ -116,7 +117,8 @@ func (us *UserStory) SetFeature(feature string) error {
 // Use with caution if you have a lot and are not setting the MaxPerPage to a high number
 // as it could cause a lot of requests to the API and may take a long time.
 // If you know you have a lot you may want to include the QueryFilter MaxPerPage
-func (c *Client) GetUserStories(filters ...QueryFilter) ([]UserStory, error) {
+//
+func (c *Client) GetUserStories(page bool, filters ...QueryFilter) ([]UserStory, error) {
 	var ret []UserStory
 	out := UserStoryResponse{}
 
@@ -125,14 +127,16 @@ func (c *Client) GetUserStories(filters ...QueryFilter) ([]UserStory, error) {
 		return nil, err
 	}
 	ret = append(ret, out.Items...)
-	for out.Next != "" {
-		innerOut := UserStoryResponse{}
-		err := c.GetNext(&innerOut, out.Next)
-		if err != nil {
-			return ret, err
+	if page {
+		for out.Next != "" {
+			innerOut := UserStoryResponse{}
+			err := c.GetNext(&innerOut, out.Next)
+			if err != nil {
+				return ret, err
+			}
+			ret = append(ret, innerOut.Items...)
+			out = innerOut
 		}
-		ret = append(ret, innerOut.Items...)
-		out = innerOut
 	}
 	return ret, nil
 }


### PR DESCRIPTION
Changes:
- BREAKING: removed Include() filter as it is not available in the v2
targetprocess API
- BREAKING: removed AssignedTeams from UserStory default struct (custom
structs can still include any fields a user would like)
- BREAKING: changed method signature of client.GetUserStories() to
include a boolean to determine if it should automatically page through
results
    - This was important for using the First() filter in this method. If
the method automatically paged with the First() filter function it would
return ALL results 1 UserStory at a time which is a lot of API calls and
woulud take a really long time.
- added ResponsibleTeam to the UserStory default struct
- added Select() and Result() filters
- added tests for each filter